### PR TITLE
Update to Play JSON 2.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,19 @@ jsonquote is built for scala 2.10 and 2.11, and published on bintray. To include
 project, simply add the desired artifact as a maven dependency for the json library you would
 like to use:
 ```scala
-resolvers += "bintray-jcenter" at "http://jcenter.bintray.com/"
+resolvers += Resolver.jcenterRepo
 
 // use the basic 'literal' json support built in to jsonquote
-libraryDependencies += "net.maffoo" %% "jsonquote-core" % "0.2.1"
+libraryDependencies += "net.maffoo" %% "jsonquote-core" % "0.4.0"
 
 // use one of the supported third-party json libraries
-libraryDependencies += "net.maffoo" %% "jsonquote-lift" % "0.2.1"
+libraryDependencies += "net.maffoo" %% "jsonquote-lift" % "0.4.0"
 
-libraryDependencies += "net.maffoo" %% "jsonquote-play" % "0.2.1"
+// note that for Scala 2.11 version 0.4.0 and above depends on play-json 2.5.X
+// older versions, as well as the artifacts published for Scala 2.10, depend on 2.4.X
+libraryDependencies += "net.maffoo" %% "jsonquote-play" % "0.4.0"
 
-libraryDependencies += "net.maffoo" %% "jsonquote-spray" % "0.2.1"
+libraryDependencies += "net.maffoo" %% "jsonquote-spray" % "0.4.0"
 
 ```
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,8 +8,8 @@ object BuildSettings {
   val buildSettings = Defaults.defaultSettings ++ Seq(
     version := "0.3.0",
     organization := "net.maffoo",
-    scalaVersion := "2.11.4",
-    crossScalaVersions := Seq("2.10.4", "2.11.4"),
+    scalaVersion := "2.11.8",
+    crossScalaVersions := Seq("2.10.6", "2.11.8"),
     scalaOrganization := "org.scala-lang",
     licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
     resolvers += Resolver.sonatypeRepo("snapshots"),
@@ -21,8 +21,8 @@ object BuildSettings {
     libraryDependencies ++= {
       scalaBinaryVersion.value match {
         case "2.10" => Seq(
-          "org.scalamacros" %% "quasiquotes" % "2.0.0",
-          compilerPlugin("org.scalamacros" % "paradise" % "2.0.0" cross CrossVersion.full)
+          "org.scalamacros" %% "quasiquotes" % "2.1.0",
+          compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
         )
         case _ => Nil
       }
@@ -68,7 +68,10 @@ object MyBuild extends Build {
     file("play"),
     settings = buildSettings ++ bintraySettings ++ Seq(
       resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
-      libraryDependencies += "com.typesafe.play" %% "play-json" % "2.4.0"
+      libraryDependencies += (scalaBinaryVersion.value match {
+        case "2.10" => "com.typesafe.play" %% "play-json" % "2.4.8"
+        case _      => "com.typesafe.play" %% "play-json" % "2.5.4"
+      })
     )
   ) dependsOn(core % "compile->compile;test->test")
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,7 +6,7 @@ import com.typesafe.sbteclipse.plugin.EclipsePlugin.EclipseKeys
 object BuildSettings {
 
   val buildSettings = Defaults.defaultSettings ++ Seq(
-    version := "0.3.0",
+    version := "0.4.0",
     organization := "net.maffoo",
     scalaVersion := "2.11.8",
     crossScalaVersions := Seq("2.10.6", "2.11.8"),


### PR DESCRIPTION
Since there is no artifact for Play JSON 2.5.4 and Scala 2.10, the versioning gets a bit tricky. I tried to clarify it in the README.