### PR TITLE
Update play json to version 2.6.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ lazy val play = project.in(file("play"))
     libraryDependencies += (scalaBinaryVersion.value match {
       case "2.10" => "com.typesafe.play" %% "play-json" % "2.4.8"
       case "2.11" => "com.typesafe.play" %% "play-json" % "2.5.4"
-      case _      => "com.typesafe.play" %% "play-json" % "2.6.0-M3"
+      case _      => "com.typesafe.play" %% "play-json" % "2.6.2"
     })
   )
 


### PR DESCRIPTION
There seems to have been a breaking change in the type of `JsArray` happened between the milestone release and the final version of 2.6. So this library must be compiled with the final version in order to work properly.