### PR TITLE
Add support for upickle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import sbt.Keys.libraryDependencies
+
 val commonSettings = Seq(
   version := "0.6.0",
   organization := "net.maffoo",
@@ -17,7 +19,7 @@ val commonSettings = Seq(
 )
 
 lazy val root = project.in(file("."))
-  .aggregate(core, json4s, lift, play, spray)
+  .aggregate(core, json4s, lift, play, spray, upickle)
   .settings(
     commonSettings,
     name := "jsonquote",
@@ -67,4 +69,13 @@ lazy val spray = project.in(file("spray"))
     commonSettings,
     name := "jsonquote-spray",
     libraryDependencies += "io.spray" %% "spray-json" % "1.3.5"
+  )
+
+lazy val upickle = project.in(file("upickle"))
+  .dependsOn(core % "compile->compile;test->test")
+  .settings(
+    commonSettings,
+    name := "jsonquote-upickle",
+    libraryDependencies += "com.lihaoyi" %% "upickle-core" % "0.8.0",
+    libraryDependencies += "com.lihaoyi" %% "upickle" % "0.8.0"
   )

--- a/upickle/src/main/scala/net/maffoo/jsonquote/upickle/Parse.scala
+++ b/upickle/src/main/scala/net/maffoo/jsonquote/upickle/Parse.scala
@@ -1,0 +1,25 @@
+package net.maffoo.jsonquote.upickle
+
+import net.maffoo.jsonquote.Parser
+import ujson._
+
+import scala.collection.immutable.ListMap
+
+object Parse extends Parser[Value, (String, Value)] {
+  def makeObject(fields: Iterable[(String, Value)]): Value = Obj.from(ListMap(fields.toSeq: _*)) // preserve iteration order until splicing is done
+  def makeArray(elements: Iterable[Value]): Value = Arr(elements.toSeq: _*)
+  def makeNumber(n: BigDecimal): Value = Num(n.toDouble)
+  def makeNumber(n: Double): Value = Num(n)
+  def makeString(s: String): Value = Str(s)
+  def makeBoolean(b: Boolean): Value = Bool(b)
+  def makeNull(): Value = Null
+  def makeSpliceValue(): Value = SpliceValue()
+  def makeSpliceValues(): Value = SpliceValues()
+
+  def makeField(k: String, v: Value): (String, Value) = (k, v)
+  def makeSpliceField(): (String, Value) = SpliceField()
+  def makeSpliceFields(): (String, Value) = SpliceFields()
+  def makeSpliceFieldNameOpt(): (String, Value) = SpliceFieldNameOpt()
+  def makeSpliceFieldName(v: Value): (String, Value) = SpliceFieldName(v)
+  def makeSpliceFieldOpt(k: String): (String, Value) = SpliceFieldOpt(k)
+}

--- a/upickle/src/main/scala/net/maffoo/jsonquote/upickle/Splice.scala
+++ b/upickle/src/main/scala/net/maffoo/jsonquote/upickle/Splice.scala
@@ -1,0 +1,57 @@
+package net.maffoo.jsonquote.upickle
+
+import ujson._
+
+import scala.util.Random
+
+// Sentinel values to mark splice points in the json AST.
+// Because spray uses Map to represent json objects, we use unique
+// random keys beginning with a known prefix to mark field splice points.
+
+class Sentinel[A <: AnyRef](inst: A) {
+  def apply(): A = inst
+  def unapply(a: A): Boolean = a == inst
+}
+
+object SpliceValue  extends Sentinel[Value](Obj.from(Map("__splice_value__" -> Null)))
+object SpliceValues extends Sentinel[Value](Obj.from(Map("__splice_values__" -> Null)))
+
+object SpliceField {
+  def apply(): (String, Value) = ("__splice_field__%016X".format(Random.nextLong), Null)
+  def unapply(a: (String, Value)): Boolean = a match {
+    case (f, Null) if f.startsWith("__splice_field__") => true
+    case _ => false
+  }
+}
+
+object SpliceFields {
+  def apply(): (String, Value) = ("__splice_fields__%016X".format(Random.nextLong), Null)
+  def unapply(a: (String, Value)): Boolean = a match {
+    case (f, Null) if f.startsWith("__splice_fields__") => true
+    case _ => false
+  }
+}
+
+object SpliceFieldNameOpt {
+  def apply(): (String, Value) = ("__splice_field_name_opt__%016X".format(Random.nextLong), Null)
+  def unapply(f: (String, Value)): Boolean = f match {
+    case (f, Null) if f.startsWith("__splice_field_name_opt__") => true
+    case _ => false
+  }
+}
+
+object SpliceFieldName {
+  def apply(x: Value): (String, Value) = ("__splice_field_name__%016X".format(Random.nextLong), x)
+  def unapply(f: (String, Value)): Option[Value] = f match {
+    case (f, x) if f.startsWith("__splice_field_name__") => Some(x)
+    case _ => None
+  }
+}
+
+object SpliceFieldOpt {
+  def apply(k: String): (String, Null) = (k, null)
+  def unapply(f: (String, Value)): Option[String] = f match {
+    case (k, null) => Some(k)
+    case _ => None
+  }
+}

--- a/upickle/src/main/scala/net/maffoo/jsonquote/upickle/package.scala
+++ b/upickle/src/main/scala/net/maffoo/jsonquote/upickle/package.scala
@@ -1,0 +1,210 @@
+package net.maffoo.jsonquote
+
+import net.maffoo.jsonquote.Macros._
+import ujson._
+import _root_.upickle.default.Writer
+
+import scala.collection.mutable
+import scala.language.experimental.macros
+
+
+package object upickle {
+  /**
+   * Rendering Value produces valid json literal
+   */
+  implicit class UpickleToLiteralJson(val json: Value) extends AnyVal {
+    def toLiteral: literal.Json = new literal.Json(json.toString())
+  }
+
+  implicit class RichJsonSringContext(val sc: StringContext) extends AnyVal {
+    def json(args: Any*): Value = macro jsonImpl
+  }
+
+  def jsonImpl(c: Context)(args: c.Expr[Any]*): c.Expr[Value] = {
+    import c.universe._
+
+    // fully-qualified symbols and types (for hygiene)
+    val nil = q"_root_.scala.collection.immutable.Nil"
+    val seq = q"_root_.scala.Seq"
+    val indexedSeq = q"_root_.scala.IndexedSeq"
+    val jsArray = q"_root_.ujson.Arr"
+    val jsObject = q"_root_.ujson.Obj"
+    val writerT = tq"_root_.upickle.default.Writer"
+
+    // convert the given json AST to a tree with arguments spliced in at the correct locations
+    def splice(js: Value)(implicit args: Iterator[Tree]): Tree = js match {
+      case SpliceValue()  => spliceValue(args.next)
+      case SpliceValues() => c.abort(c.enclosingPosition, "cannot splice values at top level")
+
+      case Obj(members) =>
+        val seqMembers = members.collect {
+          case SpliceFields()       =>
+          case SpliceFieldNameOpt() =>
+          case SpliceFieldOpt(k)    =>
+        }
+        if (seqMembers.isEmpty) {
+          val ms = members.toSeq.map {
+            case SpliceField()      => spliceField(args.next)
+            case SpliceFieldName(v) => q"(${spliceFieldName(args.next)}, ${splice(v)})"
+            case (k, v)             => q"($k, ${splice(v)})"
+          }
+          q"$jsObject(..$ms)"
+        } else {
+          val ms = members.toSeq.map {
+            case SpliceField()      => q"$seq(${spliceField(args.next)})"
+            case SpliceFields()     => spliceFields(args.next)
+            case SpliceFieldNameOpt() => spliceFieldNameOpt(args.next, args.next)
+            case SpliceFieldName(v) => q"$seq((${spliceFieldName(args.next)}, ${splice(v)}))"
+            case SpliceFieldOpt(k)  => spliceFieldOpt(k, args.next)
+            case (k, v)             => q"$seq(($k, ${splice(v)}))"
+          }
+          q"$jsObject.from($indexedSeq(..$ms).flatten)"
+        }
+
+      case Arr(elements) =>
+        val seqElems = elements.collect {
+          case SpliceValues() =>
+        }
+        if (seqElems.isEmpty) {
+          val es = elements.map {
+            case SpliceValue()  => spliceValue(args.next)
+            case e              => splice(e)
+          }
+          q"$jsArray(..$es)"
+        } else {
+          val es = elements.map {
+            case SpliceValue()  => q"$seq(${spliceValue(args.next)})"
+            case SpliceValues() => spliceValues(args.next)
+            case e              => q"$seq(${splice(e)})"
+          }
+          q"$jsArray($indexedSeq(..$es).flatten)"
+        }
+
+      case Str(s)      => q"_root_.ujson.Str($s)"
+      case Num(n)      => q"_root_.ujson.Num($n)"
+      case Bool(true)  => q"_root_.ujson.Bool(true)"
+      case Bool(false) => q"_root_.ujson.Bool(false)"
+      case Null           => q"_root_.ujson.Null"
+    }
+
+    def spliceValue(e: Tree): Tree = e.tpe match {
+      case t if t <:< c.typeOf[Value] => e
+      case t =>
+        inferWriter(e, t)
+        q"implicitly[$writerT[$t]].write($e)"
+    }
+
+    def spliceValues(e: Tree): Tree = e.tpe match {
+      case t if t <:< c.typeOf[Iterable[Value]] => e
+      case t if t <:< c.typeOf[Iterable[Any]] =>
+        val valueTpe = typeParams(lub(t :: c.typeOf[Iterable[Nothing]] :: Nil))(0)
+        val writer = inferWriter(e, valueTpe)
+        q"$e.map($writer.write)"
+
+      case t if t <:< c.typeOf[None.type] => nil
+      case t if t <:< c.typeOf[Option[Value]] => e
+      case t if t <:< c.typeOf[Option[Any]] =>
+        val valueTpe = typeParams(lub(t :: c.typeOf[Option[Nothing]] :: Nil))(0)
+        val writer = inferWriter(e, valueTpe)
+        q"$e.toIterable.map($writer.write)"
+
+      case t => c.abort(e.pos, s"required Iterable[_] but got $t")
+    }
+
+    def spliceField(e: Tree): Tree = e.tpe match {
+      case t if t <:< c.typeOf[(String, Value)] => e
+      case t if t <:< c.typeOf[(String, Any)] =>
+        val valueTpe = typeParams(lub(t :: c.typeOf[(String, Nothing)] :: Nil))(1)
+        val writer = inferWriter(e, valueTpe)
+        q"val (k, v) = $e; (k, $writer.write(v))"
+
+      case t => c.abort(e.pos, s"required (String, _) but got $t")
+    }
+
+    def spliceFields(e: Tree): Tree = e.tpe match {
+      case t if t <:< c.typeOf[Iterable[(String, Value)]] => e
+      case t if t <:< c.typeOf[Iterable[(String, Any)]] =>
+        val valueTpe = typeParams(lub(t :: c.typeOf[Iterable[(String, Nothing)]] :: Nil))(2)
+        val writer = inferWriter(e, valueTpe)
+        q"$e.map { case (k, v) => (k, $writer.write(v)) }"
+
+      case t if t <:< c.typeOf[None.type] => nil
+      case t if t <:< c.typeOf[Option[(String, Value)]] => e
+      case t if t <:< c.typeOf[Option[(String, Any)]] =>
+        val valueTpe = typeParams(lub(t :: c.typeOf[Option[(String, Nothing)]] :: Nil))(2)
+        val writer = inferWriter(e, valueTpe)
+        q"$e.toIterable.map { case (k, v) => (k, $writer.write(v)) }"
+
+      case t => c.abort(e.pos, s"required Iterable[(String, _)] but got $t")
+    }
+
+    def spliceFieldOpt(k: String, e: Tree): Tree = e.tpe match {
+      case t if t <:< c.typeOf[None.type] => nil
+      case t if t <:< c.typeOf[Option[Value]] => q"$e.toIterable.map(v => ($k, v))"
+      case t if t <:< c.typeOf[Option[Any]] =>
+        val valueTpe = typeParams(lub(t :: c.typeOf[Option[Nothing]] :: Nil))(0)
+        val writer = inferWriter(e, valueTpe)
+        q"$e.toIterable.map { v => ($k, $writer.write(v)) }"
+
+      case t => c.abort(e.pos, s"required Option[_] but got $t")
+    }
+
+    def spliceFieldName(e: Tree): Tree = e.tpe match {
+      case t if t =:= c.typeOf[String] => e
+      case t => c.abort(e.pos, s"required String but got $t")
+    }
+
+    def spliceFieldNameOpt(k: Tree, v: Tree): Tree = {
+      k.tpe match {
+        case t if t =:= c.typeOf[String] =>
+        case t => c.abort(k.pos, s"required String but got $t")
+      }
+      v.tpe match {
+        case t if t <:< c.typeOf[None.type] => nil
+        case t if t <:< c.typeOf[Option[Value]] => q"$v.toIterable.map(v => ($k, v))"
+        case t if t <:< c.typeOf[Option[Any]] =>
+          val valueTpe = typeParams(lub(t :: c.typeOf[Option[Nothing]] :: Nil))(0)
+          val writer = inferWriter(v, valueTpe)
+          q"$v.toIterable.map { v => ($k, $writer.write(v)) }"
+
+        case t => c.abort(v.pos, s"required Option[_] but got $t")
+      }
+    }
+
+    // return a list of type parameters in the given type
+    // example: List[(String, Int)] => Seq(Tuple2, String, Int)
+    def typeParams(tpe: Type): Seq[Type] = {
+      val b = Iterable.newBuilder[Type]
+      tpe.foreach(b += _)
+      b.result.drop(2).grouped(2).map(_.head).toIndexedSeq
+    }
+
+    // locate an implicit Writes[T] for the given type
+    def inferWriter(e: Tree, t: Type): Tree = {
+      val writerTpe = appliedType(c.typeOf[Writer[_]], List(t))
+      c.inferImplicitValue(writerTpe) match {
+        case EmptyTree => c.abort(e.pos, s"could not find implicit value of type JsonWriter[$t]")
+        case tree => tree
+      }
+    }
+
+    // Parse the string context parts into a json AST with holes, and then
+    // typecheck/convert args to the appropriate types and splice them in.
+    c.prefix.tree match {
+      case Apply(_, List(Apply(_, partTrees))) =>
+        val parts = partTrees map { case Literal(Constant(const: String)) => const }
+        val positions = (parts zip partTrees.map(_.pos)).toMap
+        val js = try {
+          Parse(parts)
+        } catch {
+          case JsonError(msg, Pos(s, ofs)) =>
+            val pos = positions(s)
+            c.abort(pos.withPoint(pos.point + ofs), msg)
+        }
+        c.Expr[Value](splice(js)(args.iterator.map(_.tree)))
+
+      case _ =>
+        c.abort(c.enclosingPosition, "invalid")
+    }
+  }
+}

--- a/upickle/src/test/scala/net/maffoo/jsonquote/upickle/Test.scala
+++ b/upickle/src/test/scala/net/maffoo/jsonquote/upickle/Test.scala
@@ -1,0 +1,209 @@
+package net.maffoo.jsonquote.upickle
+
+import org.scalatest.{FunSuite, Matchers}
+import ujson.{Arr, Null, Num, Obj, Str, Value}
+import upickle.default
+import upickle.default.macroRW
+
+case class Foo(bar: String, baz: String)
+
+object OptionPickler extends upickle.AttributeTagged {
+  override implicit def OptionWriter[T: Writer]: Writer[Option[T]] = {
+    implicitly[Writer[T]].comap[Option[T]] {
+      case None => null.asInstanceOf[T]
+      case Some(x) => x
+    }
+  }
+
+  override implicit def OptionReader[T: Reader]: Reader[Option[T]] = {
+    new Reader.Delegate[Any, Option[T]](implicitly[Reader[T]].map(Some(_))){
+      override def visitNull(index: Int) = None
+    }
+  }
+}
+
+class UpickleTest extends FunSuite with Matchers {
+//  import _root_.upickle.default.{macroRW}
+
+  import OptionPickler._
+  import OptionPickler.macroRW
+
+  implicit val FooRW: OptionPickler.ReadWriter[Foo] = macroRW
+
+
+  implicit def Foo2Json(foo: Foo): Value = read[Value](write(foo))
+
+  def check(js: Value, s: String): Unit = { js should equal (read[Value](s)) }
+
+  //case class Baz(s: String)
+  //json"""{test: ${Baz("test")}}"""
+
+  test("can parse plain json") {
+    check(json""" "hello!" """, """"hello!"""")
+  }
+
+  test("can use bare identifiers for object keys") {
+    check(json"{ test0: 0 }", """{ "test0": 0 }""")
+    check(json"{ test: 1 }", """{ "test": 1 }""")
+    check(json"{ test-2: 2 }", """{ "test-2": 2 }""")
+    check(json"{ test_3: 3 }", """{ "test_3": 3 }""")
+    check(json"{ _test-4: 4 }", """{ "_test-4": 4 }""")
+  }
+
+  test("can inject value with implicit Writes") {
+    val foo: Value = Foo(bar = "a", baz = "b")
+    check(json"$foo", """{"bar": "a", "baz": "b"}""")
+  }
+
+  test("can inject values with implicit Writes") {
+    val foos: List[Value] = List(Foo("1", "2"), Foo("3", "4"))
+    check(json"[..$foos]", """[{"bar":"1", "baz":"2"}, {"bar":"3", "baz":"4"}]""")
+    check(json"[..$Nil]", """[]""")
+  }
+
+  test("can inject Option values") {
+    val vOpt = Some(Num(1))
+
+    check(json"[..$vOpt]", """[1]""")
+    check(json"[..$None]" , """[]""")
+  }
+
+  test("can inject Option values with implicit Writes") {
+    val vOpt: Option[Value] = Some(1)
+    check(json"[..$vOpt]", """[1]""")
+  }
+
+  test("can mix values, Iterables and Options in array") {
+    val a: List[Value] = List("a")
+    val b: Option[Value] = Some("b")
+    val c: List[Value] = Nil
+    val d: Option[Value] = None
+    check(json"""[1, ..$a, 2, ..$b, 3, ..$c, 4, ..$d, 5]""", """[1, "a", 2, "b", 3, 4, 5]""")
+  }
+
+  test("can inject Tuple2 as object field") {
+    val kv: (String, Value) = "test" -> Foo("1", "2")
+    check(json"{$kv}", """{"test": {"bar":"1", "baz":"2"}}""")
+  }
+
+  //First one with error
+  test("can inject multiple fields") {
+    val kvs: Seq[(String, Value)] = Seq("a" -> 1, "b" -> 2)
+    val kvs2: Seq[(String, Value)] = Nil
+    check(json"{..$kvs}", """{"a": 1, "b": 2}""")
+    check(json"{..$kvs2}", """{}""")
+  }
+
+  test("can inject just a field name") {
+    val key = "foo"
+    check(json"{$key: 1}", """{"foo": 1}""")
+  }
+
+  test("can inject Option fields") {
+    val kvOpt: Option[(String, Num)] = Some("a" -> Num(1))
+    val kvOpt2: Option[(String, Num)] = None
+    check(json"{..$kvOpt}", """{"a": 1}""")
+    check(json"{..$kvOpt2}", """{}""")
+  }
+
+  test("can inject Option fields with implicit Writes") {
+    val kvOpt: Option[(String, Value)] = Some("a" -> Foo("1", "2"))
+    check(json"{..$kvOpt}", """{"a": {"bar": "1", "baz": "2"}}""")
+  }
+
+  test("can inject Option field values") {
+    val vOpt: Option[Num] = Some(Num(1))
+    val vOpt2: Option[Num] = None
+    check(json"{a:? $vOpt}", """{"a": 1}""")
+    check(json"{a:? $vOpt2}", """{}""")
+
+    val k = "a"
+    check(json"{$k:? $vOpt}", """{"a": 1}""")
+    check(json"{$k:? $vOpt2}", """{}""")
+  }
+
+  test("can inject Option field values with implicit Writes") {
+    val vOpt: Option[Value] = Some(Foo("1", "2"))
+    check(json"{a:? $vOpt}", """{"a": {"bar": "1", "baz": "2"}}""")
+  }
+
+  test("can mix values, Iterables and Options in object") {
+    val a: List[(String, Value)] = List("a" -> 10)
+    val b: Option[(String, Value)] = Some("b" -> 20)
+    val c: List[(String, Value)] = Nil
+    val d: Option[(String, Value)] = None
+    check(
+      json"""{i:1, ..$a, j:2, ..$b, k:3, ..$c, l:4, ..$d, m:5}""",
+      """{"i":1, "a":10, "j":2, "b":20, "k":3, "l":4, "m":5}"""
+    )
+  }
+
+  test("can nest jsonquote templates") {
+
+    val jsonObject = Obj.from(
+      Map(
+        "users" -> Seq(
+          Obj.from(
+            Map(
+              "name" -> Str("Bob"),
+              "age" -> Num(31),
+              "email" -> Str("bob@gmail.com")
+            )
+          ),
+          Obj.from(
+            Map(
+              "name" -> Str("Kiki"),
+              "age" -> Num(25),
+              "email" -> Null
+            )
+          )
+        )
+      )
+    )
+
+    val users: Seq[(Value, Value, Option[Value])] = Seq(("Bob", 31, Some("bob@gmail.com")), ("Kiki", 25, None))
+
+    // TODO: find a way to avoid the need for .toSeq here
+    val quoteA = json"""{
+      users: [..${
+      users.map { case (name, age, email) =>
+        json"""{
+            name: $name,
+            age: $age,
+            email:? $email
+          }"""
+      }.toSeq
+    }]
+    }"""
+
+    // play already knows how to convert Seq[JsValue] to json array
+    // still need the .toSeq here
+//    val quoteB = json"""{
+//      users: ${
+//      users.map { case (name, age, email) =>
+//        json"""{
+//            name: $name,
+//            age: $age,
+//            email:? $email
+//          }"""
+//      }.toSeq
+//    }
+//    }"""
+
+    // types inferred properly here
+    val mapped = users.map { case (name, age, email) =>
+      json"""{
+        name: $name,
+        age: $age,
+        email:? $email
+      }"""
+    }
+    val quoteC = json"""{
+      users: [..$mapped]
+    }"""
+
+    quoteA should equal (jsonObject)
+//    quoteB should equal (jsonObject)
+    quoteC should equal (jsonObject)
+  }
+}

--- a/upickle/src/test/scala/net/maffoo/jsonquote/upickle/Test.scala
+++ b/upickle/src/test/scala/net/maffoo/jsonquote/upickle/Test.scala
@@ -3,33 +3,15 @@ package net.maffoo.jsonquote.upickle
 import org.scalatest.{FunSuite, Matchers}
 import ujson.{Arr, Null, Num, Obj, Str, Value}
 import upickle.default
+import upickle.default._
 import upickle.default.macroRW
 
 case class Foo(bar: String, baz: String)
 
-object OptionPickler extends upickle.AttributeTagged {
-  override implicit def OptionWriter[T: Writer]: Writer[Option[T]] = {
-    implicitly[Writer[T]].comap[Option[T]] {
-      case None => null.asInstanceOf[T]
-      case Some(x) => x
-    }
-  }
-
-  override implicit def OptionReader[T: Reader]: Reader[Option[T]] = {
-    new Reader.Delegate[Any, Option[T]](implicitly[Reader[T]].map(Some(_))){
-      override def visitNull(index: Int) = None
-    }
-  }
-}
-
 class UpickleTest extends FunSuite with Matchers {
 //  import _root_.upickle.default.{macroRW}
 
-  import OptionPickler._
-  import OptionPickler.macroRW
-
-  implicit val FooRW: OptionPickler.ReadWriter[Foo] = macroRW
-
+  implicit val FooRW: default.ReadWriter[Foo] = macroRW
 
   implicit def Foo2Json(foo: Foo): Value = read[Value](write(foo))
 


### PR DESCRIPTION
Hi Matthew! Hey... I **almost** got upickle working, but I'm afraid I don't understand string interpolation well enough, somewhere I think it's missing a flatten, some of the tests are not passing. Do you mind taking a look at it, please?

Specifically:
```scala
[info] - can inject Option values with implicit Writes *** FAILED ***
[info]   [[1]] did not equal [1] (Test.scala:18)
```

Thanks!